### PR TITLE
Update "grunt-angular-templates" to version ~0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-angular-templates": "~0.5.4",
+    "grunt-angular-templates": "~0.6.0",
     "grunt-cli": "^0.1.13",
     "grunt-concat-sourcemap": "~0.4.1",
     "grunt-contrib-copy": "~0.8.2",


### PR DESCRIPTION
0.6.0 / 2016-01-15
==================

  * Release 0.6.0
  * Merge pull request [#142](https://github.com/ericclemmons/grunt-angular-templates/issues/142) from underscorebrody/single-quotes
    Adds an option to use single quotes instead of double for quote wrapping
  * Adds an option to use single quotes instead of double for quote wrapping
    - We are now doing manual quote wrapping instead of relying on
    JSON.stringify for greater flexibility