### PR TITLE
Update "grunt" to version ~1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/marekventur/wortopia-node/issues"
   },
   "devDependencies": {
-    "grunt": "~0.4.2",
+    "grunt": "~1.0.1",
     "grunt-angular-templates": "~1.0.1",
     "grunt-cli": "^0.1.13",
     "grunt-concat-sourcemap": "~0.4.1",


### PR DESCRIPTION
<pre>1.0.1 / 2016-04-05
==================

  * Merge pull request [#1502](https://github.com/gruntjs/grunt/issues/1502) from gruntjs/101-cli-fix
    add 1.0.1 changelog
  * add 1.0.1 changelog
  * Merge pull request [#1500](https://github.com/gruntjs/grunt/issues/1500) from gruntjs/fixbin
    Use local bin that points to grunt-cli
  * Include bin in the package.json files
  * Use local bin that points to grunt-cli

1.0.0 / 2016-04-04
==================

  * update 1.0.0 changelog
    [skip ci]
  * Merge pull request [#1498](https://github.com/gruntjs/grunt/issues/1498) from gruntjs/update-util-log
    update legacy log and util to 1.0.0
  * update legacy log and util to 1.0.0
  * Merge pull request [#1494](https://github.com/gruntjs/grunt/issues/1494) from gruntjs/cli110
    update to latest cli 1.2.0
  * update to latest cli ~1.2.0
  * Merge pull request [#1495](https://github.com/gruntjs/grunt/issues/1495) from gruntjs/grunt-known-options
    Use grunt-known-options for shared options between Grunt and grunt-cli
  * Update known options to 1.1.0 which includes b for base short option
  * Use grunt-known-options for shared options between Grunt and grunt-cli
  * Merge pull request [#1493](https://github.com/gruntjs/grunt/issues/1493) from gruntjs/fix-cli-bin
    Ensure a grunt bin gets created upon install
  * Ensure a grunt bin gets created upon install
  * Merge pull request [#1485](https://github.com/gruntjs/grunt/issues/1485) from gruntjs/rc2
    Adding 1.0.0 changelog, bumping version
  * Merge pull request [#1482](https://github.com/gruntjs/grunt/issues/1482) from arithmetric/feature/remove_duplicate_BOM_handling
    Removing duplicate BOM strip code
  * Merge pull request [#1481](https://github.com/gruntjs/grunt/issues/1481) from arithmetric/feature/update_glob
    Update glob to 7.0.x
  * Merge pull request [#1489](https://github.com/gruntjs/grunt/issues/1489) from paladox/patch-10
    Updating contrib-jshint, watch and jscs devDeps
  * Adding 1.0.0 changelog, bumping version
  * Update 3 packages
    Update grunt-contrib-jshint to 1.0.0
    Update grunt-contrib-watch to 1.0.0
    Update grunt-jscs to 2.8.0
  * Removing BOM strip code that duplicates iconv.decode() handling.
  * Update glob to 7.0.x. Fixes GH-1467
  * Merge pull request [#1480](https://github.com/gruntjs/grunt/issues/1480) from dmethvin/1478-license
    Update copyright to jQuery Foundation and remove redundant headers
  * Update copyright to jQuery Foundation and remove redundant headers
    Fixes [#1478](https://github.com/gruntjs/grunt/issues/1478)
  * Merge pull request [#1464](https://github.com/gruntjs/grunt/issues/1464) from notclive/master
    Prevent async callback from being called multiple times
  * Prevent async callback from being called multiple times
    * calling the callback multiple times would skip queued task
  * Merge pull request [#1443](https://github.com/gruntjs/grunt/issues/1443) from dmethvin/1442-test-admin
    Tests: Warn if symlinks can't be created, but continue tests

1.0.0-rc1 / 2016-02-11
======================

  * Merge pull request [#1457](https://github.com/gruntjs/grunt/issues/1457) from gruntjs/rc1
    v1.0.0-rc1
  * Updating changelog
  * v1.0.0-rc1
    Fixes [#1430](https://github.com/gruntjs/grunt/issues/1430)
  * add the new svg badge
  * Merge pull request [#1458](https://github.com/gruntjs/grunt/issues/1458) from gruntjs/vladikoff-patch-1
    disable appveyor cache
  * disable appveyor cache
    this disables appveyor cache otherwise npm will get stuck installing
  * lodash@4 .pluck() has been removed in favor of .map()
  * Tests: Warn if symlinks can't be created, but continue tests
    Ref [#1442](https://github.com/gruntjs/grunt/issues/1442)
    Windows requires Administrator privileges to create symlinks, give a warning to
    that effect but allow tests to complete (and fail).
  * No longer need to install grunt-cli globally on tests
  * Make file writeable before removing in file mode test
    Fixes GH-1442
  * Code style fixes
  * Merge pull request [#956](https://github.com/gruntjs/grunt/issues/956) from radford/write-options
    Pass the grunt.file.write options on to writeFileSync
  * Merge pull request [#1151](https://github.com/gruntjs/grunt/issues/1151) from tchollingsworth/master
    extend _.templateSettings instead of overriding it
  * Add test for loadNpmTasks
  * Fix test on Node v0.10 with sort order.
    Node v0.10 uses a different version of V8 which had a localeCompare
    sorting bug. Users should be aware of this bug if still on v0.10.
    https://github.com/isaacs/node-glob/issues/215
  * Temporarily add grunt-cli master as dep until 1.0.0-rc1 is released
  * Update js-yaml to 3.5.x
  * Update minimatch to 3.0.x
  * Chill out on the appveyor node versions as we cant rebuild when it fails
  * Update glob to 6.0.x
    Sort the order of grunt.file.expandMapping tests
    As of glob >= 4, minimatch was updated and results are sorted.
    Set the nosort: true option to not sort the results.
  * Fix windows test by updating to latest npm
    Grunt is a peerDep and so gets installed to itself. The subgrunt tests
    end up using that older version unless latest npm is used.
  * Use path-is-absolute for grunt.file.isPathAbsolute compatibility. Fixes GH-1353
  * Test on the latest version of node.js 5
  * Update dateformat to ~1.0.12
  * Update nopt to 3.0.x. Fixes GH-1421
  * Point grunt-legacy-util to master branch until published
  * Update iconv-lite dependency and preserveBOM
  * Lodash fixes for next grunt-legacy-util
  * Merge branch 'deps-cleanup'
    * deps-cleanup:
    Remove orphaned dependencies.
  * Update to coffee-script@1.10.0
  * Modernize appveyor config
  * Run tests on major supported versions of Node.js
  * Merge pull request [#1406](https://github.com/gruntjs/grunt/issues/1406) from paladox/patch-9
    Update findup-sync to 0.3.0 and lodash to 3.10.1
  * Merge pull request [#1396](https://github.com/gruntjs/grunt/issues/1396) from paladox/patch-5
    Update engine to 0.10.0
  * Merge pull request [#1331](https://github.com/gruntjs/grunt/issues/1331) from FredyC/update-coffee
    Update coffee script
  * Merge pull request [#986](https://github.com/gruntjs/grunt/issues/986) from matthew-ernewein/master
    Remove the words 'without errors.' after successfully running tasks
  * Merge pull request [#1399](https://github.com/gruntjs/grunt/issues/1399) from paladox/patch-8
    Remove node_js version 0.13.
  * Merge pull request [#1428](https://github.com/gruntjs/grunt/issues/1428) from gruntjs/node5
    include node 5 in tests
  * include node 5 in tests
  * Update copyright to 2016
  * Update findup-sync to 0.3.0 and lodash to 3.10.1
    Updating findup-sync to 0.3.0 because it currently complains that it is using a deprecated release of lodash in it.
    Updating will fix the problem.
  * Updating devDeps and fixing jscs notices
  * Remove node_js version 0.13.
  * Update package.json
  * Add node 4 to travis-ci.
    Closes gh-1394.
  * Remove node 0.8 testing
    Closes gh-1395.
  * Merge pull request [#1334](https://github.com/gruntjs/grunt/issues/1334) from pgilad/patch-1
    update license attribute
  * update license attribute
    specifying the type and URL is deprecated:
    https://docs.npmjs.com/files/package.json#license
    http://npm1k.org/
  * Using coffee-script/register
  * Updated coffee-script to 1.9
  * Squashed commit of the following:
    commit e105c80b0b2bab16999aae6974474940124c0e73
    Author: Ben Alman <cowboy@rj3.net>
    Date:   Tue May 5 12:23:10 2015 -0400
    Ensure args passed to --npm and --tasks are strings. Closes gh-1321.
    Closes gh-1323.
  * Remove orphaned dependencies.
  * Merge pull request [#1301](https://github.com/gruntjs/grunt/issues/1301) from XhmikosR/master
    Minor improvements
  * Move JSHint's options to .jshintrc.
  * Sort dependencies by name.
  * Update appveyor.yml.
  * Merge pull request [#1296](https://github.com/gruntjs/grunt/issues/1296) from XhmikosR/appveyor
    Update appveyor.yml.
  * Update appveyor.yml.
    * Remove node.js 0.8
    * Clean cache when package.json changes
  * Merge pull request [#1287](https://github.com/gruntjs/grunt/issues/1287) from mrjoelkemp/jscs_config
    JSCS config with violations fixed
  * Merge pull request [#1295](https://github.com/gruntjs/grunt/issues/1295) from XhmikosR/readme
    Update README.md.
  * JSCS config with violations fixed
  * Update README.md.
    [ci skip]
  * Merge pull request [#1294](https://github.com/gruntjs/grunt/issues/1294) from XhmikosR/readme
    Update README.md.
  * Merge pull request [#1293](https://github.com/gruntjs/grunt/issues/1293) from XhmikosR/master
    Fix tests on Windows.
  * Update README.md.
    Switch to SVG badges.
    [ci skip]
  * Fix tests on Windows.
  * Merge pull request [#1292](https://github.com/gruntjs/grunt/issues/1292) from XhmikosR/master
    Minor improvements
  * package.json: Specify the files to install.
  * Merge pull request [#1218](https://github.com/gruntjs/grunt/issues/1218) from misterdjules/ci-tests-output
    Add test-ci npm script that outputs tests results in a separate file.
  * Merge pull request [#1245](https://github.com/gruntjs/grunt/issues/1245) from vlajos/typofixes
    typo fixes
  * Update .travis.yml</pre>