### PR TITLE
Update "grunt-contrib-copy" to version ~1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-angular-templates": "~1.0.1",
     "grunt-cli": "^0.1.13",
     "grunt-concat-sourcemap": "~0.4.1",
-    "grunt-contrib-copy": "~0.8.2",
+    "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-stylus": "~1.0.0",
     "grunt-contrib-watch": "~0.6.1",
     "mocha": "~2.3.4",


### PR DESCRIPTION
<pre>1.0.0 / 2016-03-04
==================

  * v1.0.0
  * Merge pull request [#271](https://github.com/gruntjs/grunt-contrib-copy/issues/271) from gruntjs/dev
    Bump devDependencies.
  * Bump devDependencies.
  * Merge pull request [#268](https://github.com/gruntjs/grunt-contrib-copy/issues/268) from nalajcie/master
    fix syncing utimes if copied files
  * tests: disable testing timestamp equity under windows
    This test will not pass until it would be fixed in nodejs
    See: https://github.com/nodejs/node/issues/2069
  * fix syncing utimes when copying files
    fs.utimesSync saves times with one second precision, while fs.statSync gives us microsecond precision.
    This makes utimes not synchronized on filesystems with sub-second atime/ctime/mtime precision.
    Upgraded to use newer fs.futimesSync interface providing correct precision.
  * Merge pull request [#258](https://github.com/gruntjs/grunt-contrib-copy/issues/258) from ricog/patch-1
    Add example of using paths relative to `cwd`
  * Add example of using relative path
  * Merge pull request [#259](https://github.com/gruntjs/grunt-contrib-copy/issues/259) from ricog/patch-2
    Specify expand: true for single file tree example
  * Specify expand: true for single file tree example
    In order for the `Copy a single file tree` example to work as expected, I added `expand: true` to it. Otherwise it won't add the directory.
  * add appveyor
  * Update CI configs
  * Merge branch 'master' of github.com:gruntjs/grunt-contrib-copy
    * 'master' of github.com:gruntjs/grunt-contrib-copy:
    Minor lint tweaks.
  * Point main to task
  * Remove peerDeps. Ref gruntjs/grunt[#1116](https://github.com/gruntjs/grunt-contrib-copy/issues/1116)
  * Minor lint tweaks.
  * Update copyright to 2016
  * CI: Remove node.js '0.12' and add '5'.
  * copy_test.js: Clean up 'use strict' directives.</pre>