### PR TITLE
Update "mocha" to version ~2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-stylus": "~1.2.0",
     "grunt-contrib-watch": "~1.0.0",
-    "mocha": "~2.4.5",
+    "mocha": "~2.5.1",
     "nib": "~1.1.0",
     "stylus": "~0.54.2"
   },


### PR DESCRIPTION
<pre>2.5.1 / 2016-05-23
==================

  * Release v2.5.1
  * update CHANGELOG.md [ci skip]
  * to-iso-string must be a dependency

2.5.0 / 2016-05-23
==================

  * Release v2.5.0
  * rebuild mocha.js
  * update CHANGELOG.md, contributors, .mailmap
  * full browserification support; closes [#880](https://github.com/mochajs/mocha/issues/880) ([#2271](https://github.com/mochajs/mocha/issues/2271))
  * try different strategy for avoiding insecure sauce connect
  * trying to fix travis + sauce check for PRs and forks
  * don't run SauceLabs tests on PRs
  * add more unit tests for various browsers
  * Make CI run browser tests ([#2231](https://github.com/mochajs/mocha/issues/2231))
    * Initial prep for browser tests in CI
    - :arrow_up: browserify@13.0.0
    Some fixes that we didn't have were required.
    - :bug: Fix browser not being able to require describe/it
    `support/browser-entry.js` was removing the listener that is in charge
    of keeping `Mocha.describe/it/suite` etc up-to-date.
    That listener is now added everytime a `ui` is set up.
    - Correct isatty for browser
    * Travis + SauceLabs + Karma setup (first pass)
    - add sauce connect
    - prepare to use karma on saucelabs; fix potential windows problems
    - rewrite `scripts/ensure-compatible-npm.sh` in JS
    - detect travis node 0.8 env; just upgrade if found
    - symlink `mocha` to itself for `karma-mocha`
    - if explicit `--production` flag is present, skip this
    - don't know how to skip this part if `mocha` is a devDep of some other package
    - use phantomjs@1.9.19; don't try to install npm@3
    - browser tests with karma & phantom
    - move `support/browser-entry.js` to `browser-entry.js` to keep paths sane
    - `karma.conf.js` loads data out of `.karma.conf.js`
    - we have a "main" browser suite
    - then we have suites for each interface
    - each suite is a single run of Karma
    - each suite is executed by the `Makefile`
    - build `./mocha.js` upon test execution for `karma-mocha` to use
    - bonus: 3rd-party browserification should theoretically now be possible as per the `./index.js` entry in `package.json`'s `browser` field
    - add dev deps for karma
    - test changes:
    - split `lookupFiles` test into its own file so we can ignore it in Karma
    - fix broken `test/acceptance/throw.js` for browser
    - fix `test/acceptance/utils.js`'s `type` tests for PhantomJS
    - try to reduce build matrix
    - fix missing targets
    - fix infinite loop in Makefile
    - downgrade phantomjs to 1.9.8
    - remove some cruft from karma config; try to add sauce labs
    - try again w/ the saucelabs
    - typo
    - remove karma-source-map-support as it's a no-go on IE8
    - Require up-to-date mocha.js for any browser tests
    - Make CI rebuild mocha.js.  Make won't rebuild when just checked out by CI because timestamps on source and mocha.js are the same.  We could use a script to set the timestamps to the commit time, but it still wouldn't work if mocha.js were committed along with other changes that hadn't been built into it. Which shouldn't happen anyway -- but then again, the point of CI is to see what commits change, it's usually going to need to rebuild mocha.js if it's working right, so it's not going to hurt much to rebuild it every time even on the few times it doesn't need to.
    * fix IE8 compatibility for browser tests
    - Avoid `Array.prototype.map` in test
    - Workaround for missing `Object.create`
    - Use a shim for `Date.prototype.toISOString`
    - Use simple number math instead of array indexing for interface tests
    - Use `expect` instead of `should`
    - Avoid builtin function in stringify test (A quick check revealed that stringify does not treat toString specially anyway, and IE8 ignores the toString assigned to the object, so use a different property name)
    - Use `karma-expect` for automatic browser tests
    - Remove `karma-should`
    * Travis + SauceLabs + Karma setup (second pass)
    - add note about exporting `global` in `browser-entry.js`
    - remove too-short timeout for "throw" unit tests (because SauceLabs)
    - revert modification to `isatty()` function of `lib/browser/tty.js`
    - switch reporter to `karma-spec-reporter`
    - use custom `karma-no-mocha` package
    - fixtures in `test/browser-fixtures/`
    - use single `karma.conf.js`
  * Add --icu-data-dir flag for node ([#2248](https://github.com/mochajs/mocha/issues/2248))
  * Fix JSDoc ([#2219](https://github.com/mochajs/mocha/issues/2219))
  * adds node 6 to CI matrix; closes [#2239](https://github.com/mochajs/mocha/issues/2239) ([#2251](https://github.com/mochajs/mocha/issues/2251))
    * update travis matrix for node 6; use trusty image
    * add test to trigger use of glob.sync()
  * remove reserved 'maintainers' field from package.json
    this field is [used internally](https://docs.npmjs.com/files/package.json#people-fields-author-contributors) by npm; its presence may cause confusion
  * Assert that deps can be installed under node 0.8's npm ([#2236](https://github.com/mochajs/mocha/issues/2236))
  * Update README's header section ([#2214](https://github.com/mochajs/mocha/issues/2214))
    Improves the looks of the README's top/header section:
    - Updates logo to use the new design, svg hosted on Clodup
    - Center logo
    - Gives logo some top/bottom margin
  * Add new logo/banner assets ([#1841](https://github.com/mochajs/mocha/issues/1841))
  * Merge branch 'opencollective'
    * opencollective:
    reword
    Update README.md
    Added OpenCollective badge + list of backers/sponsors
  * reword
  * Merge pull request [#2201](https://github.com/mochajs/mocha/issues/2201) from astorije/patch-1
    Bump glob patch version to remove warning
  * Merge pull request [#2205](https://github.com/mochajs/mocha/issues/2205) from ScottFreeCode/fix/2204
    Correct comment label in exports interface
  * Update README.md
  * Correct comment label for exports interface
    Was "TDD-style interface", should refer to Export interface style. See
    issue [#2204](https://github.com/mochajs/mocha/issues/2204) for alternative suggestions.
  * Bump glob patch version to remove warning
    When installing `mocha@2.4.5`, `glob@3.2.3` triggers the following warning:
    ```
    npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
    ```
    This commit bumps to the latest patch version before a major version.
    Diff at https://github.com/isaacs/node-glob/compare/v3.2.3...v3.2.11.
  * Added OpenCollective badge + list of backers/sponsors
  * Merge pull request [#2145](https://github.com/mochajs/mocha/issues/2145) from Turbo87/fix-stack-filter
    Only replace absolute -> relative paths for stack lines
  * Merge pull request [#2153](https://github.com/mochajs/mocha/issues/2153) from julienw/2132-remove-dead-code
    Remove dead growl code in bin/_mocha (fixes [#2132](https://github.com/mochajs/mocha/issues/2132))
  * Merge pull request [#2162](https://github.com/mochajs/mocha/issues/2162) from OlegTsyba/doc/fix_retries_parameter_type
    doc: fix retries parameter type
  * doc: fix retries parameter type
  * Merge pull request [#2110](https://github.com/mochajs/mocha/issues/2110) from joshlory/stringify-fix
    Fix [#2109](https://github.com/mochajs/mocha/issues/2109): stringify should handle objects with non-coercible length
  * Remove dead growl code in bin/_mocha (fixes [#2132](https://github.com/mochajs/mocha/issues/2132))
    The growl functionality lives in core mocha now.
  * Merge pull request [#2124](https://github.com/mochajs/mocha/issues/2124) from benjamine/master
    updating growl dependency
  * fixing growl version
  * updating growl dependency
  * lib/utils: Only replace absolute -> relative paths for stack lines
    the stack can include the error message which might contain paths that should not be replaced
  * test/utils: Add "absolute -> relative paths" test
  * Merge pull request [#2101](https://github.com/mochajs/mocha/issues/2101) from jkimbo/non-string-error-messages
    Non string error messages
  * Handle non string error messages
  * Fix [#2109](https://github.com/mochajs/mocha/issues/2109): stringify should handle objects with non-coercible length
    Root cause is that some JS objects cannot be coerced to a Number:
    Number({toString: 0});
    TypeError: can't convert ({toString:0}) to number
    Number({a: 0});
    NaN
  * Merge pull request [#1827](https://github.com/mochajs/mocha/issues/1827) from irnc/patch-1
    Set safe CSS for progress indicator which does not conflict with Bootstrap
  * Merge pull request [#2115](https://github.com/mochajs/mocha/issues/2115) from danielstjules/dstjules/fix-browser-hooks
    Fix hook error in browser reporter by moving body prop from test to runnable
  * Merge pull request [#2081](https://github.com/mochajs/mocha/issues/2081) from mislav/is-pending
    Strenghten checks across the board for pending/skipped tests or suites
  * Merge pull request [#2097](https://github.com/mochajs/mocha/issues/2097) from mantoni/master
    fix diff for objects with custom hasOwnProperty values
  * Fix hook error in browser reporter by moving body prop from test to runnable
  * Merge pull request [#2094](https://github.com/mochajs/mocha/issues/2094) from ryym/handle-symbol
    handle Symbol values in util.stringify()
  * fix diff for objects with custom hasOwnProperty values
  * handle Symbol values in util.stringify()
    fix [#2089](https://github.com/mochajs/mocha/issues/2089)</pre>