### PR TITLE
Update "pg" to version ~5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "iz": "~0.7.1",
     "line-reader": "~0.4.0",
     "no-configuration-di": "~0.3.3",
-    "pg": "~4.5.3",
+    "pg": "~5.0.0",
     "q": "~2.0.3",
     "request": "^2.40.0",
     "serve-static": "~1.10.0",


### PR DESCRIPTION
<pre>5.0.0 / 2016-06-07
==================

  * Bump version
  * Update changelog for 5.0
  * Support for defaults.connectionString ([#910](https://github.com/brianc/node-postgres/issues/910))
  * Adding returnToHead in clientConfig param ([#1007](https://github.com/brianc/node-postgres/issues/1007))
  * Proper error message for undefined where options ([#1022](https://github.com/brianc/node-postgres/issues/1022))
    When user provides a knex select statement with an undefined options in where clause it is not properly handled an give an ambiguous error message telling `Unhandled rejection TypeError: Cannot read property 'toString' of undefined.` This PR will helpful to users at it will tell them the exact problem.
  * add dependencies badge on readme ([#1024](https://github.com/brianc/node-postgres/issues/1024))
  * added .npmignore in order to not publish tests to npm ([#1025](https://github.com/brianc/node-postgres/issues/1025))
  * pg.native returns null if pg-native is missing ([#950](https://github.com/brianc/node-postgres/issues/950))
    `require('pg').native` will be `null` and report error once to `stdout` when `pg-native` is missing.
  * pgpass: Update to 0.0.6 ([#1040](https://github.com/brianc/node-postgres/issues/1040))
  * Update Copyright notice to 2016 ([#1036](https://github.com/brianc/node-postgres/issues/1036))</pre>