### PR TITLE
Update "serve-static" to version ~1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "pg": "~4.5.3",
     "q": "~2.0.3",
     "request": "^2.40.0",
-    "serve-static": "~1.10.0",
+    "serve-static": "~1.11.0",
     "sinon": "~1.17.2",
     "sockjs": "~0.3.8",
     "underscore": "~1.8.3"


### PR DESCRIPTION
<pre>1.11.0 / 2016-06-08
===================

  * 1.11.0
  * Use status code 301 for redirects
    closes [#59](https://github.com/expressjs/serve-static/issues/59)
  * deps: send@0.14.0
    closes [#66](https://github.com/expressjs/serve-static/issues/66)
  * tests: shorten name of test
  * build: eslint-plugin-promise@1.3.2</pre>