### PR TITLE
Update "pg" to version ~6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "iz": "~0.7.1",
     "line-reader": "~0.4.0",
     "no-configuration-di": "~0.3.3",
-    "pg": "~5.2.0",
+    "pg": "~6.0.0",
     "q": "~2.0.3",
     "request": "^2.40.0",
     "serve-static": "~1.11.0",


### PR DESCRIPTION
<pre>6.0.0 / 2016-06-22
==================

  * Bump version
  * Update changelog
  * Better indication that pg.pools is a private api
  * Make tcp-keepalive configurable ([#1058](https://github.com/brianc/node-postgres/issues/1058))
  * Fix of pool leaking by TCP-keepalive ([#918](https://github.com/brianc/node-postgres/issues/918))
    * fix of bug with pool leaking by TCP keep-alives
    * add test for check setKeepAlive on connect
    * fix mistake with var
    * fix mistake with var</pre>