### PR TITLE
Update "grunt-angular-templates" to version ~1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "grunt": "~1.0.1",
-    "grunt-angular-templates": "~1.0.1",
+    "grunt-angular-templates": "~1.1.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-concat": "^1.0.0",
     "grunt-contrib-copy": "~1.0.0",


### PR DESCRIPTION
<pre>1.1.0 / 2016-08-09
==================

  * Version 1.1.0
  * Merge pull request [#114](https://github.com/ericclemmons/grunt-angular-templates/issues/114) from aaani/master
    Skip merging source files to a single destination file
  * fix rebase errors
  * Added test for the merge: false option
  * Add support for converting html templates to angular template cache without merging the output together and thus preserving the source directory structure in the output.</pre>