### PR TITLE
Update "pg" to version ~6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "iz": "~0.7.1",
     "line-reader": "~0.4.0",
     "no-configuration-di": "~0.3.3",
-    "pg": "~6.0.0",
+    "pg": "~6.1.0",
     "q": "~2.0.3",
     "request": "^2.40.0",
     "serve-static": "~1.11.0",


### PR DESCRIPTION
<pre>6.1.0 / 2016-08-11
==================

  * Bump version
  * Update changelog
  * Add callback to client#end ([#1106](https://github.com/brianc/node-postgres/issues/1106))
    A long standing bug was the pure JS client didn't accept or call a callback on `client.end`.  This is inconsistent with both the documentation & general node patterns.
    This fixes the issue & adds a test.  The issue did not exist in the native version of the client.</pre>